### PR TITLE
Adapted mpi.pxi to interface change of mpi4py: mpi4py.rc.threaded in …

### DIFF
--- a/pyfftw/mpi.pxi
+++ b/pyfftw/mpi.pxi
@@ -1658,7 +1658,12 @@ cdef class FFTW_MPI:
         # thread-parallel execution
         self._threads = threads
 
-        if self._threads > 1 and (not mpi4py.rc.threaded) or (mpi4py.rc.thread_level == 'single'):
+        try:
+            mpi4py_rc_threads = mpi4py.rc.threads
+        except AttributeError:
+            mpi4py_rc_threads = mpi4py.rc.threaded
+
+        if self._threads > 1 and (not mpi4py_rc_threads) or (mpi4py.rc.thread_level == 'single'):
             warnings.warn('MPI was not initialized with proper support for threads. '
                           'FFTW needs at least MPI_THREAD_FUNNELED. Proceeding with a single thread.')
             threads = 1


### PR DESCRIPTION
…version 2 is now called mpi4py.rc.threads.
