### PR TITLE
Convert array index to integer explicitly.

### DIFF
--- a/pyfftw/mpi.pxi
+++ b/pyfftw/mpi.pxi
@@ -1266,7 +1266,7 @@ cdef class FFTW_MPI:
         # then create a view with right dimensions for many transforms,
         # then pick out only one transform and ignore padding elements in last dimension
         arr = chunk[0:np.prod(shape)].reshape(shape)
-        return arr[..., transform:local_shape[-1] * self._howmany:self._howmany]
+        return arr[..., transform:int(local_shape[-1]*self._howmany):self._howmany]
 
     def get_input_array(self, transform=0):
         '''Return a view of the input buffer with the right conceptual dimensions; i.e.,


### PR DESCRIPTION
The lasted version of numpy (e.g. 1.12.1) does not allow for floats as array integers. For some reason the integers in `local_shape` and `self._howmany` yield a float in linea 1269 in mpi.pxi. Hence, numpy throws an exception

     TypeError: slice indices must be integers or None or have an __index__ method